### PR TITLE
Correct dataset name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # make_swe_bench_verified_mini
 
-Link to the dataset on huggingface: [https://huggingface.co/datasets/MariusHobbhahn/swe-bench-verified-tiny](https://huggingface.co/datasets/MariusHobbhahn/swe-bench-verified-tiny)
+Link to the dataset on huggingface: [https://huggingface.co/datasets/MariusHobbhahn/swe-bench-verified-mini](https://huggingface.co/datasets/MariusHobbhahn/swe-bench-verified-mini)
 
 If you use the [Inspect implementation](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/swe_bench), you can merely switch the `dataset: str = "princeton-nlp/SWE-bench_Verified",` to `dataset: str = "MariusHobbhahn/swe-bench-verified-mini",` in the "swe_bench.py" file.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Link to the dataset on huggingface: [https://huggingface.co/datasets/MariusHobbhahn/swe-bench-verified-mini](https://huggingface.co/datasets/MariusHobbhahn/swe-bench-verified-mini)
 
-If you use the [Inspect implementation](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/swe_bench), you can merely switch the `dataset: str = "princeton-nlp/SWE-bench_Verified",` to `dataset: str = "MariusHobbhahn/swe-bench-verified-mini",` in the "swe_bench.py" file.
+If you use the [Inspect implementation](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/swe_bench) you can use the `swe_bench_verified_mini` task it provides by running `inspect eval inspect_evals/swe_bench_verified_mini`.
 
 SWEBench-verified-mini is a subset of SWEBench-verified that uses 50 instead of 500 datapoints, requires 5GB instead of 130GB of storage (only using django and sphinx environments) and has approximately the same distribution of performance, test pass rates and difficulty as the original dataset on 16 different models.
 

--- a/make_new_huggingface_dataset.py
+++ b/make_new_huggingface_dataset.py
@@ -94,7 +94,7 @@ def main() -> None:
     print(f"Filtered dataset size: {filtered_dataset.num_rows} rows")
     
     # Update dataset name
-    update_dataset_name(filtered_dataset, "swe-bench-verified-tiny")
+    update_dataset_name(filtered_dataset, "swe-bench-verified-mini")
     
     # Show dataset preview
     dataset_glimpse(filtered_dataset)
@@ -107,7 +107,7 @@ def main() -> None:
     # Push to HuggingFace
     print("\nPushing dataset to HuggingFace...")
     filtered_dataset.push_to_hub(
-        "MariusHobbhahn/swe-bench-verified-tiny", 
+        "MariusHobbhahn/swe-bench-verified-mini",
         #private=True
     )
     print("Done!")


### PR DESCRIPTION
Hi, thanks for creating this dataset!

This PR updates the README and `make_new_huggingface_dataset.py` to refer to `swe-bench-verified-mini` rather than`swe-bench-verified-tiny`.

I've assumed that`swe-bench-verified-mini` is the correct name and `swe-bench-verified-tiny` is an older discontinued name.

After this PR there will still be a reference to `swe-bench-verified-tiny` in the generated `dataset_info.json`, I didn't think it was appropriate to modify the generated file in this PR.

I've also updated the README to suggest the use of the `swe_bench_verified_mini` task in inspect evals rather than modifying `swe_bench.py`.

